### PR TITLE
Comentario sobre subscripcion en Meteor

### DIFF
--- a/imports/ui/App.jsx
+++ b/imports/ui/App.jsx
@@ -189,6 +189,9 @@ App.propTypes = {
   tareasPropias: PropTypes.array
 };
 export default withTracker(() => {
+  
+  //La aplicacion Client-side tiene acceso a la informacion de todas las tareas, todos los grupos y
+  // todos los usuarios. Esto podria convertirse en un fallo de privacidad y seguridad.
   Meteor.subscribe("tareas");
   Meteor.subscribe("grupos");
 


### PR DESCRIPTION
Es buena practica suscribirse a los datos de una colección relacionados con el grupo o la persona quien se suscribe. De lo contrario, puede accederse a la información de otros grupos dentro de una sesión que no debería acceder a dicha información